### PR TITLE
Change casing of Package Reference

### DIFF
--- a/Rebus.Autofac/Rebus.Autofac.csproj
+++ b/Rebus.Autofac/Rebus.Autofac.csproj
@@ -47,7 +47,7 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="rebus" Version="4.0.0-b05" />
+    <PackageReference Include="Rebus" Version="4.0.0-b05" />
     <PackageReference Include="Autofac" Version="4.4.0" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">


### PR DESCRIPTION
Hi, 

This will change the casing of the Rebus Package Reference. Also see issue #1 

Kind Regards
  Rob 
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
