### PR TITLE
issue #14 https://github.com/rebus-org/Rebus.Autofac/issues/14

### DIFF
--- a/Rebus.Autofac.Tests/Bugs/DoesNotTryToHandleMessagesBeforeTheBusIsProperlyStarted.cs
+++ b/Rebus.Autofac.Tests/Bugs/DoesNotTryToHandleMessagesBeforeTheBusIsProperlyStarted.cs
@@ -54,6 +54,10 @@ namespace Rebus.Autofac.Tests.Bugs
                         o.SetMaxParallelism(30);
                     })
             );
+            // obtain bus instance for subscriptions...
+            builder.RegisterBuildCallback(c => {
+                var bus = c.Resolve<IBus>();
+            });
 
             builder.RegisterHandler<MyMessageHandler>();
 

--- a/Rebus.Autofac.Tests/CheckNewApi.cs
+++ b/Rebus.Autofac.Tests/CheckNewApi.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Autofac;
+using Autofac.Core;
 using NUnit.Framework;
 using Rebus.Config;
 using Rebus.Logging;
@@ -40,7 +41,7 @@ namespace Rebus.Autofac.Tests
                 .Logging(l => l.Console(minLevel: LogLevel.Debug))
                 .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "ioc-test")));
 
-            Assert.Throws<InvalidOperationException>(() =>
+            Assert.Throws<DependencyResolutionException>(() =>
             {
                 builder.Build();
             });


### PR DESCRIPTION
Hi @mookid8000, this is the solution for issue #14 
I also need the opportunity to register rebus in a child lifetime scope. (In that case registerbuildcallback doesn't help)

I hope you will apreciate this.

Leonardo
  ---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
