### PR TITLE
Multiple bus example and updated readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ _NCrunch_*
 **/packages/*
 !**/packages/build/
 AssemblyInfo_Patch.cs
+/.idea/

--- a/MessageHandlers/Properties/AssemblyInfo.cs
+++ b/MessageHandlers/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/README.md
+++ b/README.md
@@ -20,15 +20,14 @@ builder.RegisterRebus((configurer, context) => configurer
         o.SetNumberOfWorkers(2);
         o.SetMaxParallelism(30);
     }));
+    
+// Register your handlers before building the container
+builder.RegisterHandler<MyHandler>();
 
 // the bus is registered now, but it has not been started.... make all your other registrations, and then:
 var container = builder.Build(); //< start the bus
 
-
-
 // now your application is running
-
-
 
 // ALWAYS do this when your application shuts down:
 container.Dispose();
@@ -39,3 +38,61 @@ It will automatically register the following services in Autofac:
 * `IBus` – this is the bus singleton
 * `IMessageContext` – this is the current message context – can be injected into Rebus message handlers and everything resolved at the time of receiving a new message
 * `ISyncBus` – this is the synchronous bus instance – can be used in places, where a `Task`-based asynchronous API is not desired, e.g. from deep within ASP.NET or WPF applications, which would deadlock if you went `.Wait()` on a `Task`
+
+Note that you cannot register multiple buses within a single container, so if you wish to use Autofac to inject dependencies into multiple busses, you will want to create separate container builders for each bus. Then you will have multiple threads servicing each bus pointing to a different message queue, and can send messages to them from another bus. So backgrounds threads can process separate queues for instance, and your main ASP.NET application can use a one-way bus to send messages to any of the other queues. Here is an example:
+
+```csharp
+// We need a common in memory network for this example
+var inMemNetwork = new InMemNetwork();
+const string firstQueueName = "first-queue";
+const string secondQueueName = "second-queue";
+
+// Set up a single instance of the event aggregator
+var eventAggregator = new EventAggregator();
+
+// Configure container for receiving the first message type and start it up
+var firstBuilder = new ContainerBuilder();
+firstBuilder.RegisterHandler<FirstHandler>();
+firstBuilder.RegisterInstance(eventAggregator).SingleInstance();
+firstBuilder.RegisterRebus(
+    configurer => configurer
+        .Transport(t => t.UseInMemoryTransport(inMemNetwork, firstQueueName))
+        .Options(o =>
+        {
+            o.SetNumberOfWorkers(1);
+            o.SetMaxParallelism(1);
+        })
+);
+using var firstContainer = firstBuilder.Build();
+
+// Configure container for receiving the second message type and start it up
+var secondBuilder = new ContainerBuilder();
+secondBuilder.RegisterHandler<SecondHandler>();
+secondBuilder.RegisterInstance(eventAggregator).SingleInstance();
+secondBuilder.RegisterRebus(
+    configurer => configurer
+        .Transport(t => t.UseInMemoryTransport(inMemNetwork, secondQueueName))
+        .Options(o =>
+        {
+            o.SetNumberOfWorkers(1);
+            o.SetMaxParallelism(1);
+        })
+);
+using var secondContainer = secondBuilder.Build();
+
+// Now configure the bus for sending messages. This will have no worker threads.
+var sendBuilder = new ContainerBuilder();
+sendBuilder.RegisterRebus(
+    configurer => configurer
+        .Transport(t => t.UseInMemoryTransportAsOneWayClient(inMemNetwork))
+        .Routing(r => r.TypeBased()
+            .Map<FirstMessage>(firstQueueName)
+            .Map<SecondMessage>(secondQueueName))
+);
+
+using var sendContainer = sendBuilder.Build();
+var bus = sendContainer.Resolve<IBus>();
+
+await bus.Send(new FirstMessage("first message"));
+await bus.Send(new SecondMessage("second message"));
+```

--- a/Rebus.Autofac.Tests/CheckNewApi.cs
+++ b/Rebus.Autofac.Tests/CheckNewApi.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Autofac;
+﻿using Autofac;
 using Autofac.Core;
 using NUnit.Framework;
 using Rebus.Config;

--- a/Rebus.Autofac.Tests/TestMultipleContainerBuilders.cs
+++ b/Rebus.Autofac.Tests/TestMultipleContainerBuilders.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Autofac;
+using MessageHandlers;
+using NUnit.Framework;
+using Rebus.Bus;
+using Rebus.Config;
+using Rebus.Handlers;
+using Rebus.Routing.TypeBased;
+using Rebus.Transport.InMem;
+
+namespace Rebus.Autofac.Tests
+{
+    [TestFixture]
+    public class TestMultipleContainerBuilders
+    {
+        [Test]
+        public async Task MultipleRealBusesAndSeparateTransports()
+        {
+            // We need a common in memory network for this test
+            var inMemNetwork = new InMemNetwork();
+            const string firstQueueName = "first-queue";
+            const string secondQueueName = "second-queue";
+
+            // Set up a single instance of the event aggregator
+            var eventAggregator = new EventAggregator();
+
+            // Configure container for receiving the first message type and start it up
+            var firstBuilder = new ContainerBuilder();
+            firstBuilder.RegisterHandler<FirstHandler>();
+            firstBuilder.RegisterInstance(eventAggregator).SingleInstance();
+            firstBuilder.RegisterRebus(
+                configurer => configurer
+                    .Transport(t => t.UseInMemoryTransport(inMemNetwork, firstQueueName))
+                    .Options(o =>
+                    {
+                        o.SetNumberOfWorkers(1);
+                        o.SetMaxParallelism(1);
+                    })
+            );
+            using var firstContainer = firstBuilder.Build();
+
+            // Configure container for receiving the second message type and start it up
+            var secondBuilder = new ContainerBuilder();
+            secondBuilder.RegisterHandler<SecondHandler>();
+            secondBuilder.RegisterInstance(eventAggregator).SingleInstance();
+            secondBuilder.RegisterRebus(
+                configurer => configurer
+                    .Transport(t => t.UseInMemoryTransport(inMemNetwork, secondQueueName))
+                    .Options(o =>
+                    {
+                        o.SetNumberOfWorkers(1);
+                        o.SetMaxParallelism(1);
+                    })
+            );
+            using var secondContainer = secondBuilder.Build();
+
+            // Now configure the bus for sending messages. This will have no worker threads.
+            var sendBuilder = new ContainerBuilder();
+            sendBuilder.RegisterRebus(
+                configurer => configurer
+                    .Transport(t => t.UseInMemoryTransportAsOneWayClient(inMemNetwork))
+                    .Routing(r => r.TypeBased()
+                        .Map<FirstMessage>(firstQueueName)
+                        .Map<SecondMessage>(secondQueueName))
+            );
+
+            using var sendContainer = sendBuilder.Build();
+            var bus = sendContainer.Resolve<IBus>();
+
+            await bus.Send(new FirstMessage("first message"));
+            await bus.Send(new SecondMessage("second message"));
+
+            await Task.Delay(500);
+
+            var events = eventAggregator.ToList();
+
+            Assert.That(events.Count, Is.EqualTo(2));
+            Assert.AreEqual(true, events.Contains("FirstHandler handling first message"));
+            Assert.AreEqual(true, events.Contains("SecondHandler handling second message"));
+            Console.WriteLine(string.Join(Environment.NewLine, events));
+        }
+
+        class FirstMessage
+        {
+            public FirstMessage(string message)
+            {
+                Message = message;
+            }
+            public string Message;
+        }
+
+        class FirstHandler : IHandleMessages<FirstMessage>
+        {
+            public EventAggregator EventAggregator { get; set; }
+
+            public Task Handle(FirstMessage message)
+            {
+                EventAggregator.Register($"FirstHandler handling {message.Message}");
+                return Task.CompletedTask;
+            }
+        }
+
+        class SecondMessage
+        {
+            public SecondMessage(string message)
+            {
+                Message = message;
+            }
+            public string Message;
+        }
+
+        class SecondHandler : IHandleMessages<SecondMessage>
+        {
+            public EventAggregator EventAggregator { get; set; }
+
+            public Task Handle(SecondMessage message)
+            {
+                EventAggregator.Register($"SecondHandler handling {message.Message}");
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/Rebus.Autofac.sln.DotSettings
+++ b/Rebus.Autofac.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Configurer/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Rebus.Autofac/Autofac/AutofacHandlerActivator.cs
+++ b/Rebus.Autofac/Autofac/AutofacHandlerActivator.cs
@@ -5,7 +5,6 @@ using Rebus.Activation;
 using Rebus.Bus;
 using Rebus.Config;
 using Rebus.Exceptions;
-using Rebus.Extensions;
 using Rebus.Handlers;
 using Rebus.Internals;
 using Rebus.Pipeline;

--- a/Rebus.Autofac/Autofac/AutofacHandlerActivator.cs
+++ b/Rebus.Autofac/Autofac/AutofacHandlerActivator.cs
@@ -86,8 +86,7 @@ namespace Rebus.Autofac
             // regiser ISyncBus
             containerBuilder
                 .Register(c => c.Resolve<IBus>().Advanced.SyncBus)
-                .InstancePerDependency()
-                .ExternallyOwned();
+                .SingleInstance();
 
             // register IMessageContext
             containerBuilder

--- a/Rebus.Autofac/Autofac/AutofacHandlerActivator.cs
+++ b/Rebus.Autofac/Autofac/AutofacHandlerActivator.cs
@@ -83,7 +83,7 @@ namespace Rebus.Autofac
                 })
                 .SingleInstance();
 
-            // regiser ISyncBus
+            // register ISyncBus
             containerBuilder
                 .Register(c => c.Resolve<IBus>().Advanced.SyncBus)
                 .SingleInstance();

--- a/Rebus.Autofac/Config/ContainerBuilderExtensions.cs
+++ b/Rebus.Autofac/Config/ContainerBuilderExtensions.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Autofac;
 using Rebus.Autofac;
 using Rebus.Handlers;
-using Rebus.Internals;
+
 // ReSharper disable ArgumentsStyleNamedExpression
 // ReSharper disable ArgumentsStyleLiteral
 // ReSharper disable ObjectCreationAsStatement

--- a/Rebus.Autofac/Config/ContainerBuilderExtensions.cs
+++ b/Rebus.Autofac/Config/ContainerBuilderExtensions.cs
@@ -22,24 +22,24 @@ namespace Rebus.Config
         /// Makes the necessary registrations in the given <paramref name="containerBuilder"/>, invoking the
         /// <paramref name="configure"/> callback when Rebus needs to be configured.
         /// </summary>
-        public static void RegisterRebus(this ContainerBuilder containerBuilder, Func<RebusConfigurer, RebusConfigurer> configure)
+        public static void RegisterRebus(this ContainerBuilder containerBuilder, Func<RebusConfigurer, RebusConfigurer> configure, bool startBus = true, bool enablePolymorphicDispatch = false)
         {
             if (containerBuilder == null) throw new ArgumentNullException(nameof(containerBuilder));
             if (configure == null) throw new ArgumentNullException(nameof(configure));
 
-            new AutofacHandlerActivator(containerBuilder, (configurer, context) => configure(configurer), startBus: true, enablePolymorphicDispatch: false);
+            new AutofacHandlerActivator(containerBuilder, (configurer, context) => configure(configurer), startBus, enablePolymorphicDispatch);
         }
 
         /// <summary>
         /// Makes the necessary registrations in the given <paramref name="containerBuilder"/>, invoking the
         /// <paramref name="configure"/> callback when Rebus needs to be configured.
         /// </summary>
-        public static void RegisterRebus(this ContainerBuilder containerBuilder, Func<RebusConfigurer, IComponentContext, RebusConfigurer> configure)
+        public static void RegisterRebus(this ContainerBuilder containerBuilder, Func<RebusConfigurer, IComponentContext, RebusConfigurer> configure, bool startBus = true, bool enablePolymorphicDispatch = false)
         {
             if (containerBuilder == null) throw new ArgumentNullException(nameof(containerBuilder));
             if (configure == null) throw new ArgumentNullException(nameof(configure));
 
-            new AutofacHandlerActivator(containerBuilder, (configurer, context) => configure(configurer, context), startBus: true, enablePolymorphicDispatch: false);
+            new AutofacHandlerActivator(containerBuilder, (configurer, context) => configure(configurer, context), startBus, enablePolymorphicDispatch);
         }
 
         /// <summary>


### PR DESCRIPTION
Took me a while to wrap my head around how I was going to support multiple message queues with Autofac, but once you realize you need to create multiple IoC containers and have the buses run in each one, it's much clearer. I wrote a unit test showing that works to verify the concept, and updated the readme.md file showing how to do it.

Also changed the registration of ISyncBus to be a single instance, so we don't end up constantly creating a wrapper every time we need to access the bus.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
