### PR TITLE
Added support for multiple bus handlers within a single IoC container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ _NCrunch_*
 **/packages/*
 !**/packages/build/
 AssemblyInfo_Patch.cs
+/.idea/

--- a/MessageHandlers/FirstHandlerQueue/FirstHandler.cs
+++ b/MessageHandlers/FirstHandlerQueue/FirstHandler.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+using Rebus.Handlers;
+#pragma warning disable 1998
+
+namespace MessageHandlers.FirstHandlerQueue
+{
+    public class FirstHandler : IHandleMessages<FirstMessage>
+    {
+        readonly EventAggregator _eventAggregator;
+
+        public FirstHandler(EventAggregator eventAggregator) => _eventAggregator = eventAggregator;
+
+        public async Task Handle(FirstMessage message) => _eventAggregator.Register($"FirstHandler handling {message.Message}");
+    }
+}

--- a/MessageHandlers/FirstHandlerQueue/FirstMessage.cs
+++ b/MessageHandlers/FirstHandlerQueue/FirstMessage.cs
@@ -1,0 +1,11 @@
+﻿namespace MessageHandlers.FirstHandlerQueue
+{
+    public class FirstMessage : FirstQueueMessageBase
+    {
+        public FirstMessage(string message)
+        {
+            Message = message;
+        }
+        public string Message;
+    }
+}

--- a/MessageHandlers/FirstHandlerQueue/FirstQueueMessageBase.cs
+++ b/MessageHandlers/FirstHandlerQueue/FirstQueueMessageBase.cs
@@ -1,0 +1,6 @@
+﻿namespace MessageHandlers.FirstHandlerQueue
+{
+    public class FirstQueueMessageBase
+    {
+    }
+}

--- a/MessageHandlers/FirstHandlerQueue/SecondHandler.cs
+++ b/MessageHandlers/FirstHandlerQueue/SecondHandler.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+using Rebus.Handlers;
+#pragma warning disable 1998
+
+namespace MessageHandlers.FirstHandlerQueue
+{
+    public class SecondHandler : IHandleMessages<FirstMessage>
+    {
+        readonly EventAggregator _eventAggregator;
+
+        public SecondHandler(EventAggregator eventAggregator) => _eventAggregator = eventAggregator;
+
+        public async Task Handle(FirstMessage message) => _eventAggregator.Register($"SecondHandler handling {message.Message}");
+    }
+}

--- a/MessageHandlers/FirstStringHandler.cs
+++ b/MessageHandlers/FirstStringHandler.cs
@@ -1,13 +1,14 @@
 ﻿using System.Threading.Tasks;
 using Rebus.Handlers;
+#pragma warning disable 1998
 
 namespace MessageHandlers
 {
-    public class FirstHandler : IHandleMessages<string>
+    public class FirstStringHandler : IHandleMessages<string>
     {
         readonly EventAggregator _eventAggregator;
 
-        public FirstHandler(EventAggregator eventAggregator) => _eventAggregator = eventAggregator;
+        public FirstStringHandler(EventAggregator eventAggregator) => _eventAggregator = eventAggregator;
 
         public async Task Handle(string message) => _eventAggregator.Register($"FirstHandler handling {message}");
     }

--- a/MessageHandlers/Properties/AssemblyInfo.cs
+++ b/MessageHandlers/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/MessageHandlers/SecondHandlerQueue/SecondMessage.cs
+++ b/MessageHandlers/SecondHandlerQueue/SecondMessage.cs
@@ -1,0 +1,11 @@
+﻿namespace MessageHandlers.SecondHandlerQueue
+{
+    public class SecondMessage : SecondMessageQueueBase
+    {
+        public SecondMessage(string message)
+        {
+            Message = message;
+        }
+        public string Message;
+    }
+}

--- a/MessageHandlers/SecondHandlerQueue/SecondMessageQueueBase.cs
+++ b/MessageHandlers/SecondHandlerQueue/SecondMessageQueueBase.cs
@@ -1,0 +1,6 @@
+﻿namespace MessageHandlers.SecondHandlerQueue
+{
+    public class SecondMessageQueueBase
+    {
+    }
+}

--- a/MessageHandlers/SecondHandlerQueue/ThirdHandler.cs
+++ b/MessageHandlers/SecondHandlerQueue/ThirdHandler.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+using Rebus.Handlers;
+#pragma warning disable 1998
+
+namespace MessageHandlers.SecondHandlerQueue
+{
+    public class ThirdHandler : IHandleMessages<SecondMessage>
+    {
+        readonly EventAggregator _eventAggregator;
+
+        public ThirdHandler(EventAggregator eventAggregator) => _eventAggregator = eventAggregator;
+
+        public async Task Handle(SecondMessage message) => _eventAggregator.Register($"ThirdHandler handling {message.Message}");
+    }
+}

--- a/MessageHandlers/SecondStringHandler.cs
+++ b/MessageHandlers/SecondStringHandler.cs
@@ -1,13 +1,14 @@
 ﻿using System.Threading.Tasks;
 using Rebus.Handlers;
+#pragma warning disable 1998
 
 namespace MessageHandlers
 {
-    public class SecondHandler : IHandleMessages<string>
+    public class SecondStringHandler : IHandleMessages<string>
     {
         readonly EventAggregator _eventAggregator;
 
-        public SecondHandler(EventAggregator eventAggregator) => _eventAggregator = eventAggregator;
+        public SecondStringHandler(EventAggregator eventAggregator) => _eventAggregator = eventAggregator;
 
         public async Task Handle(string message) => _eventAggregator.Register($"SecondHandler handling {message}");
     }

--- a/README.md
+++ b/README.md
@@ -20,15 +20,14 @@ builder.RegisterRebus((configurer, context) => configurer
         o.SetNumberOfWorkers(2);
         o.SetMaxParallelism(30);
     }));
+    
+// Register your handlers before building the container
+builder.RegisterHandler<MyHandler>();
 
 // the bus is registered now, but it has not been started.... make all your other registrations, and then:
 var container = builder.Build(); //< start the bus
 
-
-
 // now your application is running
-
-
 
 // ALWAYS do this when your application shuts down:
 container.Dispose();
@@ -39,3 +38,70 @@ It will automatically register the following services in Autofac:
 * `IBus` – this is the bus singleton
 * `IMessageContext` – this is the current message context – can be injected into Rebus message handlers and everything resolved at the time of receiving a new message
 * `ISyncBus` – this is the synchronous bus instance – can be used in places, where a `Task`-based asynchronous API is not desired, e.g. from deep within ASP.NET or WPF applications, which would deadlock if you went `.Wait()` on a `Task`
+
+If you wish to register multiple message queue handlers within a single container, you will need to split up the registration into handlers for each queue and a one way bus for sending messages. You will also need to set up the one way bus to use type based routing and register the appropriate queues for each type. 
+
+That way you can have multiple threads servicing each bus pointing to a different message queue, and can send messages to them from another bus. So backgrounds threads can process separate queues for instance, and your main ASP.NET application can use a one-way bus to send messages to any of the other queues. 
+
+Note however that the transport used for sending messages must be of the same type with named queues. So you cannot say send some messages to a memory queue and others to a SQL queue, they will all need to be stored in the same place.  
+
+Here is an example:
+
+```csharp
+// We need a common in memory network for this test
+var inMemNetwork = new InMemNetwork();
+const string firstQueueName = "first-queue";
+const string secondQueueName = "second-queue";
+
+// Set up a single instance of the event aggregator and register it
+var builder = new ContainerBuilder();
+var eventAggregator = new EventAggregator();
+builder.RegisterInstance(eventAggregator).SingleInstance();
+
+// Configure handlers for receiving messages in the first queue and start it up
+builder.RegisterRebusMultipleHandlers<FirstQueueMessageBase>(
+    configurer => configurer
+        .Transport(t => t.UseInMemoryTransport(inMemNetwork, firstQueueName))
+        .Options(o =>
+        {
+            o.SetNumberOfWorkers(1);
+            o.SetMaxParallelism(1);
+        }));
+builder.RegisterHandlersFromAssemblyNamespaceOf<FirstQueueMessageBase>();
+
+// Configure container for receiving messages in the second queue and start it up
+builder.RegisterRebusMultipleHandlers<SecondMessageQueueBase>(
+    configurer => configurer
+        .Transport(t => t.UseInMemoryTransport(inMemNetwork, secondQueueName))
+        .Options(o =>
+        {
+            o.SetNumberOfWorkers(1);
+            o.SetMaxParallelism(1);
+        }));
+builder.RegisterHandlersFromAssemblyNamespaceOf<SecondMessageQueueBase>();
+
+// Now configure the bus for sending messages. This will have no worker threads and it's configured
+// to send messages to the two separate queues separated by namespace.
+builder.RegisterOneWayRebus(
+    configurer => configurer
+        .Transport(t => t.UseInMemoryTransportAsOneWayClient(inMemNetwork))
+        .Routing(r => r.TypeBased()
+            .MapAssemblyDerivedFrom<FirstQueueMessageBase>(firstQueueName)
+            .MapAssemblyDerivedFrom<SecondMessageQueueBase>(secondQueueName))
+);
+
+// Build the container. No busses have started up yet, as we need to start them each
+await using (_container = builder.Build())
+{
+    // Start up the event handlers
+    var firstBusStarter = _container.Resolve<IBusStarter<FirstQueueMessageBase>>();
+    firstBusStarter.Start();
+    var secondBusStarter = _container.Resolve<IBusStarter<SecondMessageQueueBase>>();
+    secondBusStarter.Start();
+
+    // Now resolve the bus we can send messages with
+    var bus = _container.Resolve<IBus>();
+    await bus.Send(new FirstMessage("first message"));
+    await bus.Send(new SecondMessage("second message"));
+}
+```

--- a/Rebus.Autofac.Tests/Bugs/RegistersHandlerAsImplementationOfIFailedForDerivedMessagesToo.cs
+++ b/Rebus.Autofac.Tests/Bugs/RegistersHandlerAsImplementationOfIFailedForDerivedMessagesToo.cs
@@ -13,6 +13,7 @@ using Rebus.Retry.Simple;
 using Rebus.Tests.Contracts;
 using Rebus.Transport;
 using Rebus.Transport.InMem;
+#pragma warning disable 1998
 
 namespace Rebus.Autofac.Tests.Bugs
 {
@@ -154,7 +155,7 @@ namespace Rebus.Autofac.Tests.Bugs
             public Dictionary<string, string> Headers { get; set; }
             public IEnumerable<Exception> Exceptions { get; set; }
         }
-        
+
         public class FailedMessage<T> : IFailed<T>
         {
             public FailedMessage(T message, string errorDescription, Dictionary<string, string> headers, IEnumerable<Exception> exceptions)

--- a/Rebus.Autofac.Tests/Bugs/RegistersHandlerAsImplementationOfIFailedToo.cs
+++ b/Rebus.Autofac.Tests/Bugs/RegistersHandlerAsImplementationOfIFailedToo.cs
@@ -13,6 +13,7 @@ using Rebus.Retry.Simple;
 using Rebus.Tests.Contracts;
 using Rebus.Transport;
 using Rebus.Transport.InMem;
+#pragma warning disable 1998
 
 namespace Rebus.Autofac.Tests.Bugs
 {

--- a/Rebus.Autofac.Tests/CheckNewApi.cs
+++ b/Rebus.Autofac.Tests/CheckNewApi.cs
@@ -1,5 +1,4 @@
 ﻿using Autofac;
-using Autofac.Core;
 using NUnit.Framework;
 using Rebus.Config;
 using Rebus.Logging;
@@ -25,25 +24,6 @@ namespace Rebus.Autofac.Tests
             var container = builder.Build();
 
             Using(container);
-        }
-
-        [Test]
-        public void ThrowsWhenAddingTwice()
-        {
-            var builder = new ContainerBuilder();
-
-            builder.RegisterRebus(configure => configure
-                .Logging(l => l.Console(minLevel: LogLevel.Debug))
-                .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "ioc-test")));
-
-            builder.RegisterRebus(configure => configure
-                .Logging(l => l.Console(minLevel: LogLevel.Debug))
-                .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "ioc-test")));
-
-            Assert.Throws<DependencyResolutionException>(() =>
-            {
-                builder.Build();
-            });
         }
     }
 }

--- a/Rebus.Autofac.Tests/CheckNewApi.cs
+++ b/Rebus.Autofac.Tests/CheckNewApi.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Autofac;
+﻿using Autofac;
 using Autofac.Core;
 using NUnit.Framework;
 using Rebus.Config;

--- a/Rebus.Autofac.Tests/CheckResolutionPerformance.cs
+++ b/Rebus.Autofac.Tests/CheckResolutionPerformance.cs
@@ -18,7 +18,7 @@ namespace Rebus.Autofac.Tests
         /*
          Initially:
 
-            
+
 Running 10 samples of 1000000 iterations
 Running sample # 1
 Running sample # 2
@@ -77,7 +77,7 @@ AVG: 4,394
 
             Refactor to local functions and collapsed typecast into one single cast:
 
-            
+
 Running 10 samples of 1000000 iterations
 Running sample # 1
 Running sample # 2

--- a/Rebus.Autofac.Tests/TestMultiHandlerRegistrationApi.cs
+++ b/Rebus.Autofac.Tests/TestMultiHandlerRegistrationApi.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Autofac;
+using Autofac.Core;
+using MessageHandlers;
+using MessageHandlers.FirstHandlerQueue;
+using MessageHandlers.SecondHandlerQueue;
+using NUnit.Framework;
+using Rebus.Bus;
+using Rebus.Config;
+using Rebus.Logging;
+using Rebus.Routing.TypeBased;
+using Rebus.Transport.InMem;
+#pragma warning disable 1998
+// ReSharper disable RedundantArgumentDefaultValue
+// ReSharper disable ArgumentsStyleNamedExpression
+
+namespace Rebus.Autofac.Tests
+{
+    [TestFixture]
+    public class TestMultiHandlerRegistrationApi
+    {
+        [Test]
+        public void RegisterOneWayRebusThrowsIfNotOneWayBus()
+        {
+            var builder = new ContainerBuilder();
+
+            builder.RegisterOneWayRebus(configure => configure
+                .Logging(l => l.Console(minLevel: LogLevel.Debug))
+                .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "ioc-test")));
+
+            Assert.Throws<DependencyResolutionException>(() =>
+            {
+                using (var container = builder.Build())
+                {
+                    // Resolve the IBus, which should throw and error if it's not one way
+                    container.Resolve<IBus>();
+                }
+            });
+        }
+
+        [Test]
+        public void RegisterOneWayRebusThrowsWhenAddingTwice()
+        {
+            var builder = new ContainerBuilder();
+
+            builder.RegisterOneWayRebus(configure => configure
+                .Logging(l => l.Console(minLevel: LogLevel.Debug))
+                .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "ioc-test")));
+
+            builder.RegisterOneWayRebus(configure => configure
+                .Logging(l => l.Console(minLevel: LogLevel.Debug))
+                .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "ioc-test")));
+
+            Assert.Throws<DependencyResolutionException>(() =>
+            {
+                builder.Build();
+            });
+        }
+
+        private IContainer _container;
+
+        [Test]
+        public async Task RealMultipleBuses()
+        {
+            // We need a common in memory network for this test
+            var inMemNetwork = new InMemNetwork();
+            const string firstQueueName = "first-queue";
+            const string secondQueueName = "second-queue";
+
+            // Set up a single instance of the event aggregator and register it
+            var builder = new ContainerBuilder();
+            var eventAggregator = new EventAggregator();
+            builder.RegisterInstance(eventAggregator).SingleInstance();
+
+            // Configure handlers for receiving messages in the first queue and start it up
+            builder.RegisterRebusMultipleHandlers<FirstQueueMessageBase>(
+                configurer => configurer
+                    .Transport(t => t.UseInMemoryTransport(inMemNetwork, firstQueueName))
+                    .Options(o =>
+                    {
+                        o.SetNumberOfWorkers(1);
+                        o.SetMaxParallelism(1);
+                    }));
+            builder.RegisterHandlersFromAssemblyNamespaceOf<FirstQueueMessageBase>();
+
+            // Configure container for receiving messages in the second queue and start it up
+            builder.RegisterRebusMultipleHandlers<SecondMessageQueueBase>(
+                configurer => configurer
+                    .Transport(t => t.UseInMemoryTransport(inMemNetwork, secondQueueName))
+                    .Options(o =>
+                    {
+                        o.SetNumberOfWorkers(1);
+                        o.SetMaxParallelism(1);
+                    }));
+            builder.RegisterHandlersFromAssemblyNamespaceOf<SecondMessageQueueBase>();
+
+            // Now configure the bus for sending messages. This will have no worker threads and it's configured
+            // to send messages to the two separate queues separated by namespace.
+            builder.RegisterOneWayRebus(
+                configurer => configurer
+                    .Transport(t => t.UseInMemoryTransportAsOneWayClient(inMemNetwork))
+                    .Routing(r => r.TypeBased()
+                        .MapAssemblyDerivedFrom<FirstQueueMessageBase>(firstQueueName)
+                        .MapAssemblyDerivedFrom<SecondMessageQueueBase>(secondQueueName))
+            );
+
+            // Build the container. No busses have started up yet, as we need to start them each
+            await using (_container = builder.Build())
+            {
+                // Start up the event handlers
+                var firstBusStarter = _container.Resolve<IBusStarter<FirstQueueMessageBase>>();
+                firstBusStarter.Start();
+                var secondBusStarter = _container.Resolve<IBusStarter<SecondMessageQueueBase>>();
+                secondBusStarter.Start();
+
+                // Now resolve the bus we can send messages with
+                var bus = _container.Resolve<IBus>();
+                await bus.Send(new FirstMessage("HI THERE"));
+                await bus.Send(new FirstMessage("HOW ARE YOU?"));
+                await bus.Send(new SecondMessage("HI THERE"));
+                await bus.Send(new SecondMessage("HOW ARE YOU?"));
+
+                // Wait for the messages to get received in the handler threads
+                await Task.Delay(500);
+
+                // Check it all worked
+                var events = _container.Resolve<EventAggregator>().OrderBy(s => s).ToList();
+                Assert.That(events.Count, Is.EqualTo(6));
+                Assert.AreEqual(events[0], "FirstHandler handling HI THERE");
+                Assert.AreEqual(events[1], "FirstHandler handling HOW ARE YOU?");
+                Assert.AreEqual(events[2], "SecondHandler handling HI THERE");
+                Assert.AreEqual(events[3], "SecondHandler handling HOW ARE YOU?");
+                Assert.AreEqual(events[4], "ThirdHandler handling HI THERE");
+                Assert.AreEqual(events[5], "ThirdHandler handling HOW ARE YOU?");
+                Console.WriteLine(string.Join(Environment.NewLine, events));
+            }
+        }
+    }
+}

--- a/Rebus.Autofac.Tests/TestRegistrationApi.cs
+++ b/Rebus.Autofac.Tests/TestRegistrationApi.cs
@@ -3,12 +3,17 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Autofac;
+using Autofac.Core;
 using MessageHandlers;
 using NUnit.Framework;
 using Rebus.Bus;
+using Rebus.Bus.Advanced;
 using Rebus.Config;
 using Rebus.Handlers;
+using Rebus.Logging;
 using Rebus.Transport.InMem;
+// ReSharper disable RedundantArgumentDefaultValue
+// ReSharper disable ArgumentsStyleNamedExpression
 
 namespace Rebus.Autofac.Tests
 {
@@ -40,30 +45,52 @@ namespace Rebus.Autofac.Tests
         }
 
         [Test]
-        public void ItWorks_Multiple()
+        public void ItWorks_AssemblyOf()
         {
             var builder = new ContainerBuilder();
 
             builder.RegisterType<EventAggregator>().SingleInstance();
-            builder.RegisterHandlersFromAssemblyOf<FirstHandler>();
+            builder.RegisterHandlersFromAssemblyOf<FirstStringHandler>();
 
             using (var container = builder.Build())
             {
-                var stringHandlers = container.Resolve<IEnumerable<IHandleMessages<string>>>().ToList();
+                var stringHandlers = container.Resolve<IEnumerable<IHandleMessages<string>>>().OrderBy(t => t.GetType().FullName) .ToList();
 
                 Assert.That(stringHandlers.Count, Is.EqualTo(2));
+                Assert.That(stringHandlers[0], Is.TypeOf<FirstStringHandler>());
+                Assert.That(stringHandlers[1], Is.TypeOf<SecondStringHandler>());
             }
+        }
+
+        [Test]
+        public void RegisterRebusThrowsWhenAddingTwice()
+        {
+            var builder = new ContainerBuilder();
+
+            builder.RegisterRebus(configure => configure
+                .Logging(l => l.Console(minLevel: LogLevel.Debug))
+                .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "ioc-test")));
+
+            builder.RegisterRebus(configure => configure
+                .Logging(l => l.Console(minLevel: LogLevel.Debug))
+                .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "ioc-test")));
+
+            Assert.Throws<DependencyResolutionException>(() =>
+            {
+                builder.Build();
+            });
         }
 
         [Test]
         public async Task RealBusAndStuff_Single()
         {
+            // First register some handlers
             var builder = new ContainerBuilder();
-
-            builder.RegisterHandler<FirstHandler>();
-            builder.RegisterHandler<SecondHandler>();
-
+            builder.RegisterHandler<FirstStringHandler>();
+            builder.RegisterHandler<SecondStringHandler>();
             builder.RegisterType<EventAggregator>().SingleInstance();
+
+            // Now register the bus
             builder.RegisterRebus(
                 configurer => configurer
                     .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "doesn't matter"))
@@ -74,30 +101,40 @@ namespace Rebus.Autofac.Tests
                     })
             );
 
+            // Build the IoC container, which starts the bus
             using (var container = builder.Build())
             {
+                // Test sending a message via the async bus
                 var bus = container.Resolve<IBus>();
-
                 await bus.SendLocal("HEJ MED DIG");
-                await bus.SendLocal("HVORDAN GÅR DET?");
 
+                // Test sending a message via the sync bus
+                var syncBus = container.Resolve<ISyncBus>();
+                syncBus.SendLocal("HVORDAN GÅR DET?");
+
+                // Wait for the messages to get received in the handler threads
                 await Task.Delay(500);
 
-                var events = container.Resolve<EventAggregator>().ToList();
-
+                // Check it all worked
+                var events = container.Resolve<EventAggregator>().OrderBy(s => s).ToList();
                 Assert.That(events.Count, Is.EqualTo(4));
+                Assert.AreEqual(events[0], "FirstHandler handling HEJ MED DIG");
+                Assert.AreEqual(events[1], "FirstHandler handling HVORDAN GÅR DET?");
+                Assert.AreEqual(events[2], "SecondHandler handling HEJ MED DIG");
+                Assert.AreEqual(events[3], "SecondHandler handling HVORDAN GÅR DET?");
                 Console.WriteLine(string.Join(Environment.NewLine, events));
             }
         }
 
         [Test]
-        public async Task RealBusAndStuff_Multiple()
+        public async Task RealBusAndStuff_AssemblyOf()
         {
+            // First register some handlers. There will be three of them.
             var builder = new ContainerBuilder();
-
-            builder.RegisterHandlersFromAssemblyOf<FirstHandler>();
-
+            builder.RegisterHandlersFromAssemblyOf<FirstStringHandler>();
             builder.RegisterType<EventAggregator>().SingleInstance();
+
+            // Now register the bus
             builder.RegisterRebus(
                 configurer => configurer
                     .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "doesn't matter"))
@@ -108,18 +145,66 @@ namespace Rebus.Autofac.Tests
                     })
             );
 
+            // Build the IoC container, which starts the bus
             using (var container = builder.Build())
             {
+                // Test sending a message via the async bus
                 var bus = container.Resolve<IBus>();
-
                 await bus.SendLocal("HEJ MED DIG");
-                await bus.SendLocal("HVORDAN GÅR DET?");
 
+                // Test sending a message via the sync bus
+                var syncBus = container.Resolve<ISyncBus>();
+                syncBus.SendLocal("HVORDAN GÅR DET?");
+
+                // Wait for the messages to get received in the handler threads
                 await Task.Delay(500);
 
-                var events = container.Resolve<EventAggregator>().ToList();
-
+                // Check it all worked
+                var events = container.Resolve<EventAggregator>().OrderBy(s => s).ToList();
                 Assert.That(events.Count, Is.EqualTo(4));
+                Assert.AreEqual(events[0], "FirstHandler handling HEJ MED DIG");
+                Assert.AreEqual(events[1], "FirstHandler handling HVORDAN GÅR DET?");
+                Assert.AreEqual(events[2], "SecondHandler handling HEJ MED DIG");
+                Assert.AreEqual(events[3], "SecondHandler handling HVORDAN GÅR DET?");
+                Console.WriteLine(string.Join(Environment.NewLine, events));
+            }
+        }
+
+        private IContainer _container;
+
+        [Test]
+        public async Task RealBusAndStuff_LifetimeScopeCallback()
+        {
+            // First register a handler
+            var builder = new ContainerBuilder();
+            builder.RegisterHandler<FirstStringHandler>();
+            builder.RegisterType<EventAggregator>().SingleInstance();
+
+            // Now register the bus
+            builder.RegisterRebus(
+                configurer => configurer
+                    .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "doesn't matter"))
+                    .Options(o =>
+                    {
+                        o.SetNumberOfWorkers(1);
+                        o.SetMaxParallelism(1);
+                    }));
+
+            // Build the IoC container, which starts the bus
+            using (_container = builder.Build())
+            {
+                // Test sending a message via the async bus
+                var bus = _container.Resolve<IBus>();
+                await bus.SendLocal("HEJ MED DIG");
+
+
+                // Wait for the messages to get received in the handler threads
+                await Task.Delay(500);
+
+                // Check it all worked
+                var events = _container.Resolve<EventAggregator>().ToList();
+                Assert.That(events.Count, Is.EqualTo(1));
+                Assert.AreEqual(events[0], "FirstHandler handling HEJ MED DIG");
                 Console.WriteLine(string.Join(Environment.NewLine, events));
             }
         }

--- a/Rebus.Autofac.sln.DotSettings
+++ b/Rebus.Autofac.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Configurer/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Rebus.Autofac/Autofac/AutofacHandlerActivator.cs
+++ b/Rebus.Autofac/Autofac/AutofacHandlerActivator.cs
@@ -5,7 +5,6 @@ using Rebus.Activation;
 using Rebus.Bus;
 using Rebus.Config;
 using Rebus.Exceptions;
-using Rebus.Extensions;
 using Rebus.Handlers;
 using Rebus.Internals;
 using Rebus.Pipeline;

--- a/Rebus.Autofac/Autofac/AutofacHandlerActivator.cs
+++ b/Rebus.Autofac/Autofac/AutofacHandlerActivator.cs
@@ -86,8 +86,7 @@ namespace Rebus.Autofac
             // regiser ISyncBus
             containerBuilder
                 .Register(c => c.Resolve<IBus>().Advanced.SyncBus)
-                .InstancePerDependency()
-                .ExternallyOwned();
+                .SingleInstance();
 
             // register IMessageContext
             containerBuilder

--- a/Rebus.Autofac/Autofac/AutofacHandlerActivator.cs
+++ b/Rebus.Autofac/Autofac/AutofacHandlerActivator.cs
@@ -83,7 +83,7 @@ namespace Rebus.Autofac
                 })
                 .SingleInstance();
 
-            // regiser ISyncBus
+            // register ISyncBus
             containerBuilder
                 .Register(c => c.Resolve<IBus>().Advanced.SyncBus)
                 .SingleInstance();

--- a/Rebus.Autofac/Autofac/AutofacHandlerActivator.cs
+++ b/Rebus.Autofac/Autofac/AutofacHandlerActivator.cs
@@ -61,7 +61,8 @@ namespace Rebus.Autofac
                 });
             _startBus = startBus;
 
-            // Register IBus. When this is resolved, the bus starts up.
+            // Register IBus. When this is resolved, the bus starts up. This is also disposable, so when the IBus is disposed,
+            // it will shut down all it's handlers.
             containerBuilder
                 .Register(context =>
                 {

--- a/Rebus.Autofac/Autofac/AutofacHelpers.cs
+++ b/Rebus.Autofac/Autofac/AutofacHelpers.cs
@@ -9,6 +9,7 @@ using Rebus.Handlers;
 using Rebus.Internals;
 using Rebus.Retry.Simple;
 using Rebus.Transport;
+// ReSharper disable ArgumentsStyleLiteral
 #pragma warning disable 1998
 
 namespace Rebus.Autofac

--- a/Rebus.Autofac/Autofac/AutofacHelpers.cs
+++ b/Rebus.Autofac/Autofac/AutofacHelpers.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Concurrent;
+using Autofac.Core;
+using Rebus.Bus;
+using System.Collections.Generic;
+using System.Linq;
+using Autofac;
+using Rebus.Handlers;
+using Rebus.Internals;
+using Rebus.Retry.Simple;
+using Rebus.Transport;
+#pragma warning disable 1998
+
+namespace Rebus.Autofac
+{
+    internal static class AutofacHelpers
+    {
+        /// <summary>
+        /// Returns true if the IBus interface has been registered multiple times, which is bad
+        /// </summary>
+        /// <param name="registrations">Registrations to check</param>
+        /// <returns>True if registered multiple times</returns>
+        public static bool HasMultipleBusRegistrations(IEnumerable<IComponentRegistration> registrations) =>
+            registrations.SelectMany(r => r.Services)
+                .OfType<TypedService>()
+                .Count(s => s.ServiceType == typeof(IBus)) > 1;
+
+        /// <summary>
+        /// Resolves all the handlers for a particular message type via Autofac
+        /// </summary>
+        /// <param name="transactionContext">Transaction context for the handler</param>
+        /// <param name="container">Autofac container for creating a new lifetime scope in a new transaction context</param>
+        /// <param name="resolvers">Cache of resolves to cache and look them up in</param>
+        /// <param name="handlerBaseType">Base type of handler to expect, null to allow them all</param>
+        /// <typeparam name="TMessage">Type of message we want to handle</typeparam>
+        /// <returns>Enumeration of resolved handlers for this message type</returns>
+        public static IEnumerable<IHandleMessages<TMessage>> ResolveAutofacHandlers<TMessage>(ITransactionContext transactionContext, ILifetimeScope container,
+            ConcurrentDictionary<Type, Func<ILifetimeScope, IEnumerable<IHandleMessages>>> resolvers, Type handlerBaseType)
+        {
+            // Get the resolver for creating the handlers for this type from the cache, and create it if not present
+            var resolver = resolvers.GetOrAdd(typeof(TMessage), messageType => CreateResolveEnumeration<TMessage>(handlerBaseType));
+
+            // Create a new lifetime scope for this handler if required in the transaction context
+            var lifetimeScope = transactionContext.GetOrAdd("current-autofac-lifetime-scope", () => CreateLifetimeScope(transactionContext, container));
+
+            // Now run the resolver for this lifetime scope to create the handlers injected via Autofac for a particular lifetime scope
+            return (IEnumerable<IHandleMessages<TMessage>>) resolver(lifetimeScope);
+        }
+
+        /// <summary>
+        /// Creates the resolver enumeration to generate a list of handlers for a specific message type
+        /// </summary>
+        /// <param name="handlerBaseType">Base type of handler to expect, null to allow them all</param>
+        /// <typeparam name="TMessage">Type of message we want to handle</typeparam>
+        /// <returns>Enumeration of resolved handlers for this message type</returns>
+        private static Func<ILifetimeScope, IEnumerable<IHandleMessages>> CreateResolveEnumeration<TMessage>(Type handlerBaseType)
+        {
+            // If this message is not derived from the base class we expect, then return no handlers
+            var messageType = typeof(TMessage);
+            if (handlerBaseType != null && !messageType.IsAssignableTo(handlerBaseType))
+            {
+                return scope => new IHandleMessages<TMessage>[0];
+            }
+
+            if (messageType.IsAssignableTo(typeof(IFailed<>)))
+            {
+                var containedMessageType = messageType.GetGenericTypeParameters(typeof(IFailed<>)).Single();
+                var additionalTypesToResolveHandlersFor = containedMessageType.GetBaseTypes(includeSelf: false);
+                var typesToResolve = new[] {containedMessageType}
+                    .Concat(additionalTypesToResolveHandlersFor)
+                    .Select(type => typeof(IEnumerable<>).MakeGenericType(typeof(IHandleMessages<>).MakeGenericType(typeof(IFailed<>).MakeGenericType(type))))
+                    .ToArray();
+
+                return scope =>
+                {
+                    var handlers = new List<IHandleMessages<TMessage>>();
+
+                    foreach (var type in typesToResolve)
+                    {
+                        handlers.AddRange((IEnumerable<IHandleMessages<TMessage>>) scope.Resolve(type));
+                    }
+
+                    return handlers;
+                };
+            }
+
+            return scope => scope.Resolve<IEnumerable<IHandleMessages<TMessage>>>();
+        }
+
+        /// <summary>
+        /// Creates a new lifetime scope within the transaction context, and registers it to be disposed of when the transaction scope is disposed
+        /// </summary>
+        /// <param name="transactionContext">Transaction context for the handler</param>
+        /// <param name="container">Autofac container for creating a new lifetime scope in a new transaction context</param>
+        /// <returns>Lifetime scope to use for this transaction scope</returns>
+        private static ILifetimeScope CreateLifetimeScope(ITransactionContext transactionContext, ILifetimeScope container)
+        {
+            var scope = container.BeginLifetimeScope();
+            transactionContext.OnDisposed(ctx => scope.Dispose());
+            return scope;
+        }
+    }
+}

--- a/Rebus.Autofac/Autofac/AutofacMultipleHandlersActivator.cs
+++ b/Rebus.Autofac/Autofac/AutofacMultipleHandlersActivator.cs
@@ -1,9 +1,7 @@
 ﻿using Autofac;
 using Autofac.Features.Variance;
 using Rebus.Activation;
-using Rebus.Bus;
 using Rebus.Config;
-using Rebus.Exceptions;
 using Rebus.Handlers;
 using Rebus.Pipeline;
 using Rebus.Transport;
@@ -40,7 +38,8 @@ namespace Rebus.Autofac
                     e.Instance._container = e.Context.Resolve<ILifetimeScope>();
                 });
 
-            // Register IBusStarter so the message handlers can be started up
+            // Register IBusStarter so the message handlers can be started up. This is also disposable, so when the IBus is disposed,
+            // it will shut down all it's handlers.
             containerBuilder
                 .Register(context =>
                 {

--- a/Rebus.Autofac/Autofac/AutofacOneWayBusActivator.cs
+++ b/Rebus.Autofac/Autofac/AutofacOneWayBusActivator.cs
@@ -1,0 +1,67 @@
+﻿using Autofac;
+using Rebus.Activation;
+using Rebus.Bus;
+using Rebus.Config;
+using Rebus.Handlers;
+using Rebus.Transport;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Rebus.Autofac
+{
+    class AutofacOneWayBusActivator : IHandlerActivator
+    {
+        const string MoreThanOneBusExceptionMessage =
+            "This particular container builder seems to have had the RegisterOneWayRebus(...) extension called on it more than once, which is unfortunately not allowed. This is simply an indication that the configuration code for some reason has been executed more than once, which is probably not intended.";
+        const string NotOneWayBusExceptionMessage =
+            "This particular container builder has NOT been configured as a one way bus. Please make sure the transport is configured as a one way bus so there are no handler threads required.";
+
+        public AutofacOneWayBusActivator(ContainerBuilder containerBuilder, Action<RebusConfigurer, IComponentContext> configureBus)
+        {
+            if (containerBuilder == null) throw new ArgumentNullException(nameof(containerBuilder));
+            if (configureBus == null) throw new ArgumentNullException(nameof(configureBus));
+
+            // Register autofac one way bus starter and make sure it was not registered multiple times
+            containerBuilder.RegisterInstance(this).As<AutofacOneWayBusActivator>()
+                .AutoActivate()
+                .SingleInstance()
+                .OnActivated(e =>
+                {
+                    var container = e.Context.Resolve<ILifetimeScope>();
+                    if (AutofacHelpers.HasMultipleBusRegistrations(container.ComponentRegistry.Registrations))
+                    {
+                        throw new InvalidOperationException(MoreThanOneBusExceptionMessage);
+                    }
+                });
+
+            // Register IBus. This is a one way bus so it does not actually start anything. We also make sure it's configured as a one way bus.
+            containerBuilder
+                .Register(context =>
+                {
+                    var rebusConfigurer = Configure.With(this);
+                    configureBus.Invoke(rebusConfigurer, context);
+                    var bus = rebusConfigurer.Start();
+                    if (bus.Advanced.Workers.Count > 0)
+                    {
+                        throw new InvalidOperationException(NotOneWayBusExceptionMessage);
+                    }
+                    return bus;
+                })
+                .SingleInstance();
+
+            // register ISyncBus
+            containerBuilder
+                .Register(c => c.Resolve<IBus>().Advanced.SyncBus)
+                .SingleInstance();
+        }
+
+        /// <summary>
+        /// Resolves all handlers for the given <typeparamref name="TMessage"/> message type
+        /// </summary>
+        public Task<IEnumerable<IHandleMessages<TMessage>>> GetHandlers<TMessage>(TMessage message, ITransactionContext transactionContext)
+        {
+            throw new InvalidOperationException(NotOneWayBusExceptionMessage);
+        }
+    }
+}

--- a/Rebus.Autofac/Autofac/BusStarter.cs
+++ b/Rebus.Autofac/Autofac/BusStarter.cs
@@ -9,7 +9,7 @@ namespace Rebus.Autofac
     public class BusStarter<THandlerBase> : IBusStarter<THandlerBase>
         where THandlerBase : class
     {
-        private readonly IBusStarter _busStarter;
+        private IBusStarter _busStarter;
 
         /// <summary>
         /// Constructor for the bus stater wrapper class
@@ -27,6 +27,17 @@ namespace Rebus.Autofac
         public void Start()
         {
             _busStarter.Start();
+        }
+
+        /// <summary>
+        /// Called when the context containing this bus handler is disposed, so dispose of our containing
+        /// bus which will shut down all it's workers.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_busStarter == null) return;
+            _busStarter.Bus.Dispose();
+            _busStarter = null;
         }
     }
 }

--- a/Rebus.Autofac/Autofac/BusStarter.cs
+++ b/Rebus.Autofac/Autofac/BusStarter.cs
@@ -1,0 +1,32 @@
+﻿using Rebus.Config;
+
+namespace Rebus.Autofac
+{
+    /// <summary>
+    /// Class to start up the handlers for a registered queue. When <see cref="Start"/> is called,
+    /// workers are added, and message processing will start.
+    /// </summary>
+    public class BusStarter<THandlerBase> : IBusStarter<THandlerBase>
+        where THandlerBase : class
+    {
+        private readonly IBusStarter _busStarter;
+
+        /// <summary>
+        /// Constructor for the bus stater wrapper class
+        /// </summary>
+        /// <param name="busStarter">Bus stater for this bus instance</param>
+        public BusStarter(
+            IBusStarter busStarter)
+        {
+            _busStarter = busStarter;
+        }
+
+        /// <summary>
+        /// Starts message processing handlers for this queue
+        /// </summary>
+        public void Start()
+        {
+            _busStarter.Start();
+        }
+    }
+}

--- a/Rebus.Autofac/Autofac/IBusStarter.cs
+++ b/Rebus.Autofac/Autofac/IBusStarter.cs
@@ -1,0 +1,15 @@
+﻿namespace Rebus.Autofac
+{
+    /// <summary>
+    /// Interface to start up the handlers for a registered queue. When <see cref="Start"/> is called,
+    /// workers are added, and message processing will start.
+    /// </summary>
+    public interface IBusStarter<THandlerBase>
+        where THandlerBase : class
+    {
+        /// <summary>
+        /// Starts message processing handlers for this queue
+        /// </summary>
+        void Start();
+    }
+}

--- a/Rebus.Autofac/Autofac/IBusStarter.cs
+++ b/Rebus.Autofac/Autofac/IBusStarter.cs
@@ -1,10 +1,12 @@
-﻿namespace Rebus.Autofac
+﻿using System;
+
+namespace Rebus.Autofac
 {
     /// <summary>
     /// Interface to start up the handlers for a registered queue. When <see cref="Start"/> is called,
     /// workers are added, and message processing will start.
     /// </summary>
-    public interface IBusStarter<THandlerBase>
+    public interface IBusStarter<THandlerBase> : IDisposable
         where THandlerBase : class
     {
         /// <summary>

--- a/Rebus.Autofac/Config/ContainerBuilderExtensions.cs
+++ b/Rebus.Autofac/Config/ContainerBuilderExtensions.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Autofac;
 using Rebus.Autofac;
 using Rebus.Handlers;
-using Rebus.Internals;
+
 // ReSharper disable ArgumentsStyleNamedExpression
 // ReSharper disable ArgumentsStyleLiteral
 // ReSharper disable ObjectCreationAsStatement

--- a/Rebus.Autofac/Config/ContainerBuilderExtensions.cs
+++ b/Rebus.Autofac/Config/ContainerBuilderExtensions.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Autofac;
 using Rebus.Autofac;
 using Rebus.Handlers;
-
 // ReSharper disable ArgumentsStyleNamedExpression
 // ReSharper disable ArgumentsStyleLiteral
 // ReSharper disable ObjectCreationAsStatement
@@ -19,7 +18,9 @@ namespace Rebus.Config
     {
         /// <summary>
         /// Makes the necessary registrations in the given <paramref name="containerBuilder"/>, invoking the
-        /// <paramref name="configure"/> callback when Rebus needs to be configured.
+        /// <paramref name="configure"/> callback when Rebus needs to be configured. You can only have a single
+        /// bus and set of handlers registered within an Autofac IoC container. If you wish to have multiple handlers, you will need
+        /// to split up the bus into a one way bus, and multiple handler registrations.
         /// </summary>
         public static void RegisterRebus(this ContainerBuilder containerBuilder, Func<RebusConfigurer, RebusConfigurer> configure, bool startBus = true, bool enablePolymorphicDispatch = false)
         {
@@ -31,7 +32,9 @@ namespace Rebus.Config
 
         /// <summary>
         /// Makes the necessary registrations in the given <paramref name="containerBuilder"/>, invoking the
-        /// <paramref name="configure"/> callback when Rebus needs to be configured.
+        /// <paramref name="configure"/> callback when Rebus needs to be configured. You can only have a single
+        /// bus and set of handlers registered within an Autofac IoC container. If you wish to have multiple handlers, you will need
+        /// to split up the bus into a one way bus, and multiple handler registrations.
         /// </summary>
         public static void RegisterRebus(this ContainerBuilder containerBuilder, Func<RebusConfigurer, IComponentContext, RebusConfigurer> configure, bool startBus = true, bool enablePolymorphicDispatch = false)
         {
@@ -42,17 +45,109 @@ namespace Rebus.Config
         }
 
         /// <summary>
+        /// Makes the necessary registrations in the given <paramref name="containerBuilder"/>, invoking the
+        /// <paramref name="configure"/> callback when Rebus needs to be configured as a one way bus. You can only have a single
+        /// one way bus registered within an Autofac IoC container for sending messages.
+        /// </summary>
+        public static void RegisterOneWayRebus(this ContainerBuilder containerBuilder, Func<RebusConfigurer, RebusConfigurer> configure)
+        {
+            if (containerBuilder == null) throw new ArgumentNullException(nameof(containerBuilder));
+            if (configure == null) throw new ArgumentNullException(nameof(configure));
+
+            new AutofacOneWayBusActivator(containerBuilder, (configurer, context) => configure(configurer));
+        }
+
+        /// <summary>
+        /// Makes the necessary registrations in the given <paramref name="containerBuilder"/>, invoking the
+        /// <paramref name="configure"/> callback when Rebus needs to be configured as a one way bus. You can only have a single
+        /// one way bus registered within an Autofac IoC container for sending messages.
+        /// </summary>
+        public static void RegisterOneWayRebus(this ContainerBuilder containerBuilder, Func<RebusConfigurer, IComponentContext, RebusConfigurer> configure)
+        {
+            if (containerBuilder == null) throw new ArgumentNullException(nameof(containerBuilder));
+            if (configure == null) throw new ArgumentNullException(nameof(configure));
+
+            new AutofacOneWayBusActivator(containerBuilder, (configurer, context) => configure(configurer, context));
+        }
+
+        /// <summary>
+        /// Makes the necessary registrations in the given <paramref name="containerBuilder"/>, invoking the
+        /// <paramref name="configure"/> callback when Rebus needs to be configured. You can only have a single
+        /// bus and set of handlers registered within an Autofac IoC container. If you wish to have multiple handlers, you will need
+        /// to split up the bus into a one way bus, and multiple handler registrations.
+        /// </summary>
+        public static void RegisterRebusMultipleHandlers<THandlerBase>(this ContainerBuilder containerBuilder, Func<RebusConfigurer, RebusConfigurer> configure, bool enablePolymorphicDispatch = false)
+            where THandlerBase : class
+        {
+            if (containerBuilder == null) throw new ArgumentNullException(nameof(containerBuilder));
+            if (configure == null) throw new ArgumentNullException(nameof(configure));
+
+            new AutofacMultipleHandlersActivator<THandlerBase>(containerBuilder, (configurer, context) => configure(configurer), enablePolymorphicDispatch);
+        }
+
+        /// <summary>
+        /// Makes the necessary registrations in the given <paramref name="containerBuilder"/>, invoking the
+        /// <paramref name="configure"/> callback when Rebus needs to be configured. You can only have a single
+        /// bus and set of handlers registered within an Autofac IoC container. If you wish to have multiple handlers, you will need
+        /// to split up the bus into a one way bus, and multiple handler registrations.
+        /// </summary>
+        public static void RegisterRebusMultipleHandlers<THandlerBase>(this ContainerBuilder containerBuilder, Func<RebusConfigurer, IComponentContext, RebusConfigurer> configure, bool enablePolymorphicDispatch = false)
+            where THandlerBase : class
+        {
+            if (containerBuilder == null) throw new ArgumentNullException(nameof(containerBuilder));
+            if (configure == null) throw new ArgumentNullException(nameof(configure));
+
+            new AutofacMultipleHandlersActivator<THandlerBase>(containerBuilder, (configurer, context) => configure(configurer, context), enablePolymorphicDispatch);
+        }
+
+        /// <summary>
         /// Registers all Rebus message handler types found in the assembly of <typeparamref name="T"/>
         /// </summary>
-        public static void RegisterHandlersFromAssemblyOf<T>(this ContainerBuilder builder)
+        public static void RegisterHandlersFromAssemblyOf<T>(this ContainerBuilder builder, PropertyWiringOptions propertyWiringOptions = PropertyWiringOptions.None)
+        {
+            RegisterHandlersFromAssemblyOf(builder, typeof(T), propertyWiringOptions);
+        }
+
+        /// <summary>
+        /// Registers all Rebus message handler types found in the assembly of <paramref name="handlerType"/>
+        /// </summary>
+        public static void RegisterHandlersFromAssemblyOf(this ContainerBuilder builder, Type handlerType, PropertyWiringOptions propertyWiringOptions = PropertyWiringOptions.None)
         {
             if (builder == null) throw new ArgumentNullException(nameof(builder));
+            if (handlerType == null) throw new ArgumentNullException(nameof(handlerType));
 
-            builder.RegisterAssemblyTypes(typeof(T).Assembly)
+            builder.RegisterAssemblyTypes(handlerType.Assembly)
                 .Where(t => t.IsClass && !t.IsAbstract && t.GetInterfaces().Any(IsRebusHandler))
                 .As(GetImplementedHandlerInterfaces)
                 .InstancePerDependency()
-                .PropertiesAutowired();
+                .PropertiesAutowired(propertyWiringOptions);
+        }
+
+        /// <summary>
+        /// Registers all Rebus message handler types found in the assembly of <typeparamref name="T"/> under the namespace that type lives
+        /// under. So all types within the same namespace will get mapped as handlers, but not types under other namespaces. This allows
+        /// you to separate messages for specific queues by namespace and register them all in one go.
+        /// </summary>
+        public static void RegisterHandlersFromAssemblyNamespaceOf<T>(this ContainerBuilder builder, PropertyWiringOptions propertyWiringOptions = PropertyWiringOptions.None)
+        {
+            RegisterHandlersFromAssemblyNamespaceOf(builder, typeof(T), propertyWiringOptions);
+        }
+
+        /// <summary>
+        /// Registers all Rebus message handler types found in the assembly of <paramref name="handlerType"/> under the namespace that type lives
+        /// under. So all types within the same namespace will get mapped as handlers, but not types under other namespaces. This allows
+        /// you to separate messages for specific queues by namespace and register them all in one go.
+        /// </summary>
+        public static void RegisterHandlersFromAssemblyNamespaceOf(this ContainerBuilder builder, Type handlerType, PropertyWiringOptions propertyWiringOptions = PropertyWiringOptions.None)
+        {
+            if (builder == null) throw new ArgumentNullException(nameof(builder));
+            if (handlerType == null) throw new ArgumentNullException(nameof(handlerType));
+
+            builder.RegisterAssemblyTypes(handlerType.Assembly)
+                .Where(t => t.IsClass && !t.IsAbstract && t.GetInterfaces().Any(IsRebusHandler) && t.Namespace != null && t.Namespace.StartsWith(handlerType.Namespace ?? string.Empty))
+                .As(GetImplementedHandlerInterfaces)
+                .InstancePerDependency()
+                .PropertiesAutowired(propertyWiringOptions);
         }
 
         /// <summary>
@@ -66,7 +161,7 @@ namespace Rebus.Config
 
             builder.RegisterType(typeof(THandler)).As(implementedHandlerTypes)
                 .InstancePerDependency()
-                .PropertiesAutowired();
+                .PropertiesAutowired(PropertyWiringOptions.AllowCircularDependencies);
         }
 
         static IEnumerable<Type> GetImplementedHandlerInterfaces(Type handlerType) => handlerType.GetInterfaces().Where(IsRebusHandler);

--- a/Rebus.Autofac/Config/ContainerBuilderExtensions.cs
+++ b/Rebus.Autofac/Config/ContainerBuilderExtensions.cs
@@ -22,24 +22,24 @@ namespace Rebus.Config
         /// Makes the necessary registrations in the given <paramref name="containerBuilder"/>, invoking the
         /// <paramref name="configure"/> callback when Rebus needs to be configured.
         /// </summary>
-        public static void RegisterRebus(this ContainerBuilder containerBuilder, Func<RebusConfigurer, RebusConfigurer> configure)
+        public static void RegisterRebus(this ContainerBuilder containerBuilder, Func<RebusConfigurer, RebusConfigurer> configure, bool startBus = true, bool enablePolymorphicDispatch = false)
         {
             if (containerBuilder == null) throw new ArgumentNullException(nameof(containerBuilder));
             if (configure == null) throw new ArgumentNullException(nameof(configure));
 
-            new AutofacHandlerActivator(containerBuilder, (configurer, context) => configure(configurer), startBus: true, enablePolymorphicDispatch: false);
+            new AutofacHandlerActivator(containerBuilder, (configurer, context) => configure(configurer), startBus, enablePolymorphicDispatch);
         }
 
         /// <summary>
         /// Makes the necessary registrations in the given <paramref name="containerBuilder"/>, invoking the
         /// <paramref name="configure"/> callback when Rebus needs to be configured.
         /// </summary>
-        public static void RegisterRebus(this ContainerBuilder containerBuilder, Func<RebusConfigurer, IComponentContext, RebusConfigurer> configure)
+        public static void RegisterRebus(this ContainerBuilder containerBuilder, Func<RebusConfigurer, IComponentContext, RebusConfigurer> configure, bool startBus = true, bool enablePolymorphicDispatch = false)
         {
             if (containerBuilder == null) throw new ArgumentNullException(nameof(containerBuilder));
             if (configure == null) throw new ArgumentNullException(nameof(configure));
 
-            new AutofacHandlerActivator(containerBuilder, (configurer, context) => configure(configurer, context), startBus: true, enablePolymorphicDispatch: false);
+            new AutofacHandlerActivator(containerBuilder, (configurer, context) => configure(configurer, context), startBus, enablePolymorphicDispatch);
         }
 
         /// <summary>


### PR DESCRIPTION
Added support for multiple handlers in a single container so you can use the same IoC pipeline to send messages to multiple queues, and process those messages from multiple queues within the same IoC container with different threads. It works by using type based routing and excluding handlers except those that are derived from the types you want in each queue.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
