### PR TITLE
Minor cleanups and some features exposed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ _NCrunch_*
 **/packages/*
 !**/packages/build/
 AssemblyInfo_Patch.cs
+/.idea/

--- a/MessageHandlers/FirstHandler.cs
+++ b/MessageHandlers/FirstHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Rebus.Handlers;
+#pragma warning disable 1998
 
 namespace MessageHandlers
 {

--- a/MessageHandlers/SecondHandler.cs
+++ b/MessageHandlers/SecondHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Rebus.Handlers;
+#pragma warning disable 1998
 
 namespace MessageHandlers
 {

--- a/Rebus.Autofac.Tests/Bugs/RegistersHandlerAsImplementationOfIFailedForDerivedMessagesToo.cs
+++ b/Rebus.Autofac.Tests/Bugs/RegistersHandlerAsImplementationOfIFailedForDerivedMessagesToo.cs
@@ -13,6 +13,7 @@ using Rebus.Retry.Simple;
 using Rebus.Tests.Contracts;
 using Rebus.Transport;
 using Rebus.Transport.InMem;
+#pragma warning disable 1998
 
 namespace Rebus.Autofac.Tests.Bugs
 {
@@ -154,7 +155,7 @@ namespace Rebus.Autofac.Tests.Bugs
             public Dictionary<string, string> Headers { get; set; }
             public IEnumerable<Exception> Exceptions { get; set; }
         }
-        
+
         public class FailedMessage<T> : IFailed<T>
         {
             public FailedMessage(T message, string errorDescription, Dictionary<string, string> headers, IEnumerable<Exception> exceptions)

--- a/Rebus.Autofac.Tests/Bugs/RegistersHandlerAsImplementationOfIFailedToo.cs
+++ b/Rebus.Autofac.Tests/Bugs/RegistersHandlerAsImplementationOfIFailedToo.cs
@@ -13,6 +13,7 @@ using Rebus.Retry.Simple;
 using Rebus.Tests.Contracts;
 using Rebus.Transport;
 using Rebus.Transport.InMem;
+#pragma warning disable 1998
 
 namespace Rebus.Autofac.Tests.Bugs
 {

--- a/Rebus.Autofac/Autofac/AutofacHandlerActivator.cs
+++ b/Rebus.Autofac/Autofac/AutofacHandlerActivator.cs
@@ -5,7 +5,6 @@ using Rebus.Activation;
 using Rebus.Bus;
 using Rebus.Config;
 using Rebus.Exceptions;
-using Rebus.Extensions;
 using Rebus.Handlers;
 using Rebus.Internals;
 using Rebus.Pipeline;
@@ -16,7 +15,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-// ReSharper disable ArgumentsStyleLiteral
 #pragma warning disable 1998
 
 namespace Rebus.Autofac
@@ -39,11 +37,11 @@ namespace Rebus.Autofac
                 containerBuilder.RegisterSource(new ContravariantRegistrationSource());
             }
 
-            //register autofac starter
+            // Register autofac starter
             containerBuilder.RegisterInstance(this).As<AutofacHandlerActivator>()
                 .AutoActivate()
                 .SingleInstance()
-                .OnActivated((e) =>
+                .OnActivated(e =>
                 {
                     if (e.Instance._container == null)
                     {
@@ -54,6 +52,7 @@ namespace Rebus.Autofac
                         throw new InvalidOperationException(LongExceptionMessage);
                     }
 
+                    // Start the bus up if requested
                     if (e.Instance._startBus)
                     {
                         try
@@ -68,7 +67,7 @@ namespace Rebus.Autofac
                 });
             _startBus = startBus;
 
-            // register IBus
+            // Register IBus
             containerBuilder
                 .Register(context =>
                 {
@@ -83,13 +82,13 @@ namespace Rebus.Autofac
                 })
                 .SingleInstance();
 
-            // regiser ISyncBus
+            // Register ISyncBus, resolved from IBus
             containerBuilder
                 .Register(c => c.Resolve<IBus>().Advanced.SyncBus)
                 .InstancePerDependency()
                 .ExternallyOwned();
 
-            // register IMessageContext
+            // Register IMessageContext
             containerBuilder
                 .Register(c =>
                 {
@@ -122,8 +121,7 @@ namespace Rebus.Autofac
                 return scope;
             }
 
-            var lifetimeScope = transactionContext
-                .GetOrAdd("current-autofac-lifetime-scope", CreateLifetimeScope);
+            var lifetimeScope = transactionContext.GetOrAdd("current-autofac-lifetime-scope", CreateLifetimeScope);
 
             var resolver = _resolvers.GetOrAdd(typeof(TMessage),
                 messageType =>


### PR DESCRIPTION
Minor cleanups, added the ability to not start the bus to the registration API's, and also added the ability to set the property autowiring options for registration of handlers.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
